### PR TITLE
Freedom for Minimap Mods

### DIFF
--- a/mods/xaeros-minimap.pw.toml
+++ b/mods/xaeros-minimap.pw.toml
@@ -1,6 +1,6 @@
 name = "Xaero's Minimap"
 filename = "Xaeros_Minimap_23.5.0_Forge_1.18.2.jar"
-side = "both"
+side = "client"
 
 [download]
 hash-format = "sha1"

--- a/mods/xaeros-world-map.pw.toml
+++ b/mods/xaeros-world-map.pw.toml
@@ -1,6 +1,6 @@
 name = "Xaero's World Map"
 filename = "XaerosWorldMap_1.30.3_Forge_1.18.2.jar"
-side = "both"
+side = "client"
 
 [download]
 hash-format = "sha1"


### PR DESCRIPTION
**Remove Xaero's maps from the server-side**
Their presence, to my knowledge, is unnecessary as the server does not leverage any MultiWord technology.
Removal will allow players to use their personally preferred mapping mods for whatever reason they choose:
- eg. personally, I use JourneyMap for its webmap features, so I can have a large map (with entities, etc.) on another monitor